### PR TITLE
feat: archiving and granular network statuses

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knocklabs/client",
-  "version": "0.4.5-rc.2",
+  "version": "0.4.5-rc.3",
   "description": "The clientside library for interacting with Knock",
   "homepage": "https://github.com/knocklabs/knock-client-js",
   "author": "@knocklabs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knocklabs/client",
-  "version": "0.4.4",
+  "version": "0.4.5-rc.1",
   "description": "The clientside library for interacting with Knock",
   "homepage": "https://github.com/knocklabs/knock-client-js",
   "author": "@knocklabs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@knocklabs/client",
-  "version": "0.4.5-rc.1",
+  "version": "0.4.5-rc.2",
   "description": "The clientside library for interacting with Knock",
   "homepage": "https://github.com/knocklabs/knock-client-js",
   "author": "@knocklabs",

--- a/src/clients/Feed/Feed.ts
+++ b/src/clients/Feed/Feed.ts
@@ -157,6 +157,7 @@ class Feed {
     // Build the new metadata
     const meta = {
       ...state.metadata,
+      total_count: state.metadata.total_count - normalizedItems.length,
       unseen_count: state.metadata.unseen_count - unseenCount,
       unread_count: state.metadata.unread_count - unreadCount,
     };

--- a/src/clients/Feed/interfaces.ts
+++ b/src/clients/Feed/interfaces.ts
@@ -1,4 +1,5 @@
 import { Activity, GenericData, User, PageInfo } from "../../interfaces";
+import { NetworkStatus } from "../../networkStatus";
 
 // Specific feed interfaces
 
@@ -13,6 +14,10 @@ export interface FeedClientOptions {
   tenant?: string;
   include_archived?: boolean;
 }
+
+export type FetchFeedOptions = {
+  __loadingType?: NetworkStatus.loading | NetworkStatus.fetchMore;
+} & FeedClientOptions;
 
 export interface ContentBlock {
   content: string;

--- a/src/clients/Feed/store.ts
+++ b/src/clients/Feed/store.ts
@@ -1,4 +1,5 @@
 import create from "zustand/vanilla";
+import { NetworkStatus } from "../../networkStatus";
 import { FeedItem } from "./interfaces";
 import { FeedStoreState } from "./types";
 import { deduplicateItems, sortItems } from "./utils";
@@ -17,21 +18,36 @@ const defaultSetResultOptions = {
 
 export default function createStore() {
   return create<FeedStoreState>((set) => ({
+    // Keeps track of all of the items loaded
     items: [],
+
+    // The network status indicates what's happening with the request
+    networkStatus: NetworkStatus.ready,
     loading: false,
+
     // Keeps track of the current badge counts
     metadata: {
       total_count: 0,
       unread_count: 0,
       unseen_count: 0,
     },
+
     // Keeps track of the last full page of results we received (for paginating)
     pageInfo: {
       before: null,
       after: null,
       page_size: 50,
     },
+
+    // TODO: remove this function from the store as we're now using the
+    // `setNetworkStatus` function to derive this information instead
     setLoading: (loading) => set(() => ({ loading })),
+
+    setNetworkStatus: (networkStatus: NetworkStatus) =>
+      set(() => ({
+        networkStatus,
+        loading: networkStatus === NetworkStatus.loading,
+      })),
 
     setResult: (
       { entries, meta, page_info },
@@ -48,6 +64,7 @@ export default function createStore() {
           metadata: meta,
           pageInfo: options.shouldSetPage ? page_info : state.pageInfo,
           loading: false,
+          networkStatus: NetworkStatus.ready,
         };
       }),
 

--- a/src/clients/Feed/types.ts
+++ b/src/clients/Feed/types.ts
@@ -1,4 +1,5 @@
 import { PageInfo } from "../../interfaces";
+import { NetworkStatus } from "../../networkStatus";
 import { FeedItem, FeedMetadata, FeedResponse } from "./interfaces";
 
 export type StoreFeedResultOptions = {
@@ -11,9 +12,11 @@ export type FeedStoreState = {
   pageInfo: PageInfo;
   metadata: FeedMetadata;
   loading: boolean;
+  networkStatus: NetworkStatus;
   setResult: (response: FeedResponse, opts?: StoreFeedResultOptions) => void;
   setMetadata: (metadata: FeedMetadata) => void;
   setLoading: (loading: boolean) => void;
+  setNetworkStatus: (networkStatus: NetworkStatus) => void;
   setItemAttrs: (itemIds: string[], attrs: object) => void;
 };
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ export * from "./interfaces";
 export * from "./clients/feed/types";
 export * from "./clients/feed/interfaces";
 export * from "./clients/preferences/interfaces";
+export * from "./networkStatus";
 
 export default Knock;
 export { Feed, FeedClient };

--- a/src/networkStatus.ts
+++ b/src/networkStatus.ts
@@ -1,0 +1,19 @@
+export enum NetworkStatus {
+  // Performing a top level loading operation
+  loading = "loading",
+
+  // Performing a fetch more on some already loaded data
+  fetchMore = "fetchMore",
+
+  // No operation is currently in progress
+  ready = "ready",
+
+  // The last operation failed with an error
+  error = "error",
+}
+
+export function isRequestInFlight(networkStatus: NetworkStatus): boolean {
+  return [NetworkStatus.loading, NetworkStatus.fetchMore].includes(
+    networkStatus,
+  );
+}


### PR DESCRIPTION
* Introduced a new `NetworkStatus` enum and corresponding `networkStatus` state exposed in the feed state, which can be used to differentiate between 'loading' and 'fetching more' 
* Added a new optimistic archiving of feed items such that the items are now removed from the feed when the `include_archived` flag is not true

Both of these updates are used in the new `0.5.0` release of the notifications feed