### PR TITLE
feat: triggered by

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,11 @@ const feedClient = knockClient.feeds.initialize(
 const teardown = feedClient.listenForUpdates();
 
 // Setup a callback for when a batch of messages is received (including on first load)
-feedClient.on("messages.new", ({ entries }) => {
-  console.log(entries);
+feedClient.on("messages.new", ({ entries, triggeredBy }) => {
+  // Filter messages if you only interested in updates via socket
+  if (triggeredBy === "socket") {
+    console.log(entries);
+  }
 });
 
 // Fetch the feed items

--- a/src/clients/Feed/feed.ts
+++ b/src/clients/Feed/feed.ts
@@ -9,6 +9,7 @@ import {
   FeedRealTimeEvent,
   FeedItemOrItems,
   FeedStoreState,
+  FeedRealTimeCallbackPayload,
 } from "./types";
 import {
   FeedItem,
@@ -242,7 +243,10 @@ class Feed {
       setState((state) => state.setResult(response));
     }
 
-    this.broadcast("messages.new", response);
+    this.broadcast("messages.new", {
+      ...response,
+      triggeredBy: options.__triggeredBy,
+    });
     return { data: response, status: result.statusCode };
   }
 
@@ -262,7 +266,7 @@ class Feed {
     });
   }
 
-  private broadcast(eventName: FeedRealTimeEvent, data: FeedResponse) {
+  private broadcast(eventName: FeedRealTimeEvent, data: FeedRealTimeCallbackPayload) {
     this.broadcaster.emit(eventName, data);
   }
 
@@ -277,7 +281,10 @@ class Feed {
     // Optimistically set the badge counts
     setState((state) => state.setMetadata(metadata));
     // Fetch the items before the current head (if it exists)
-    this.fetch({ before: currentHead?.__cursor });
+    this.fetch({
+      before: currentHead?.__cursor,
+      __triggeredBy: "socket",
+    });
   }
 
   private buildUserFeedId() {

--- a/src/clients/Feed/interfaces.ts
+++ b/src/clients/Feed/interfaces.ts
@@ -46,7 +46,7 @@ export interface FeedItem {
   seen_at: string | null;
   total_activities: number;
   total_actors: number;
-  data: GenericData;
+  data: GenericData | null;
   source: NotificationSource;
 }
 

--- a/src/clients/Feed/interfaces.ts
+++ b/src/clients/Feed/interfaces.ts
@@ -15,8 +15,11 @@ export interface FeedClientOptions {
   include_archived?: boolean;
 }
 
+export type TriggeredBy = "socket" | "user";
+
 export type FetchFeedOptions = {
   __loadingType?: NetworkStatus.loading | NetworkStatus.fetchMore;
+  __triggeredBy?: TriggeredBy;
 } & FeedClientOptions;
 
 export interface ContentBlock {

--- a/src/clients/Feed/types.ts
+++ b/src/clients/Feed/types.ts
@@ -1,6 +1,6 @@
 import { PageInfo } from "../../interfaces";
 import { NetworkStatus } from "../../networkStatus";
-import { FeedItem, FeedMetadata, FeedResponse } from "./interfaces";
+import { FeedItem, FeedMetadata, FeedResponse, TriggeredBy } from "./interfaces";
 
 export type StoreFeedResultOptions = {
   shouldSetPage?: boolean;
@@ -24,8 +24,12 @@ export type FeedMessagesReceivedPayload = {
   metadata: FeedMetadata;
 };
 
+export type FeedRealTimeCallbackPayload = {
+  triggeredBy?: TriggeredBy;
+} & FeedResponse;
+
 export type FeedRealTimeEvent = "messages.new";
 
-export type FeedRealTimeCallback = (resp: FeedResponse) => void;
+export type FeedRealTimeCallback = (resp: FeedRealTimeCallbackPayload) => void;
 
 export type FeedItemOrItems = FeedItem | FeedItem[];


### PR DESCRIPTION
- add `triggeredBy` option to "real time" callback payload in order to identify wether data fetch was triggered by socket or via user communication