### PR TITLE
feat(feeds): adds new items.new and items.fetched event

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,12 +68,17 @@ const feedClient = knockClient.feeds.initialize(
 const teardown = feedClient.listenForUpdates();
 
 // Setup a callback for when a batch of items is received (including on first load and subsequent page load)
-feedClient.on("items.fetched", ({ items }) => {
+feedClient.on("items.received.page", ({ items }) => {
   console.log(items);
 });
 
 // Setup a callback for when new items arrive in real-time
-feedClient.on("items.new", ({ items }) => {
+feedClient.on("items.received.realtime", ({ items }) => {
+  console.log(items);
+});
+
+// Listen to all received items
+feedClient.on("items.received.*", ({ items }) => {
   console.log(items);
 });
 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,14 @@ const feedClient = knockClient.feeds.initialize(
 // Connect to the real-time socket
 const teardown = feedClient.listenForUpdates();
 
-// Setup a callback for when a batch of messages is received (including on first load)
-feedClient.on("messages.new", ({ entries }) => {
-  console.log(entries);
+// Setup a callback for when a batch of items is received (including on first load and subsequent page load)
+feedClient.on("items.fetched", ({ items }) => {
+  console.log(items);
+});
+
+// Setup a callback for when new items arrive in real-time
+feedClient.on("items.new", ({ items }) => {
+  console.log(items);
 });
 
 // Fetch the feed items

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -44,7 +44,7 @@ function App() {
       console.log(data);
     });
 
-    feedClient.on("items.new", (data) => {
+    feedClient.on("items.received.*", (data) => {
       console.log(data);
     });
 

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo } from "react";
 import "./App.css";
 import Knock from "@knocklabs/client";
 import create from "zustand";
@@ -21,7 +21,6 @@ const useNotificationFeed = (knockClient, feedId) => {
 };
 
 function App() {
-  const [prefs, setPrefs] = useState();
   const [feedClient, feedStore] = useNotificationFeed(
     knockClient,
     process.env.REACT_APP_KNOCK_CHANNEL_ID,
@@ -42,6 +41,10 @@ function App() {
     const teardown = feedClient.listenForUpdates();
 
     feedClient.on("messages.new", (data) => {
+      console.log(data);
+    });
+
+    feedClient.on("items.new", (data) => {
       console.log(data);
     });
 

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "axios": "^0.21.4",
     "axios-retry": "^3.1.9",
-    "eventemitter3": "^4.0.7",
+    "eventemitter2": "^6.4.5",
     "phoenix": "1.5.8",
     "zustand": "^3.5.10"
   }

--- a/src/clients/Feed/feed.ts
+++ b/src/clients/Feed/feed.ts
@@ -51,7 +51,7 @@ class Feed {
     this.feedId = feedId;
     this.userFeedId = this.buildUserFeedId();
     this.store = createStore();
-    this.broadcaster = new EventEmitter({ wildcard: true });
+    this.broadcaster = new EventEmitter({ wildcard: true, delimiter: "." });
     this.defaultOptions = options;
 
     // Try and connect to the socket

--- a/src/clients/Feed/feed.ts
+++ b/src/clients/Feed/feed.ts
@@ -10,7 +10,7 @@ import {
   FeedItemOrItems,
   FeedStoreState,
   FeedEventPayload,
-  NewMessagesFeedEventCallback,
+  FeedRealTimeCallback,
 } from "./types";
 import {
   FeedItem,
@@ -85,16 +85,13 @@ class Feed {
   }
 
   /* Binds a handler to be invoked when event occurs */
-  on(
-    eventName: FeedEvent,
-    callback: FeedEventCallback | NewMessagesFeedEventCallback,
-  ) {
+  on(eventName: FeedEvent, callback: FeedEventCallback | FeedRealTimeCallback) {
     this.broadcaster.on(eventName, callback);
   }
 
   off(
     eventName: FeedEvent,
-    callback: FeedEventCallback | NewMessagesFeedEventCallback,
+    callback: FeedEventCallback | FeedRealTimeCallback,
   ) {
     this.broadcaster.off(eventName, callback);
   }

--- a/src/clients/Feed/interfaces.ts
+++ b/src/clients/Feed/interfaces.ts
@@ -45,7 +45,7 @@ export interface FeedItem<T = GenericData> {
   archived_at: string | null;
   total_activities: number;
   total_actors: number;
-  data: T;
+  data: T | null;
   source: NotificationSource;
 }
 

--- a/src/clients/Feed/interfaces.ts
+++ b/src/clients/Feed/interfaces.ts
@@ -17,6 +17,7 @@ export interface FeedClientOptions {
 
 export type FetchFeedOptions = {
   __loadingType?: NetworkStatus.loading | NetworkStatus.fetchMore;
+  __fetchSource?: "socket" | "http";
 } & FeedClientOptions;
 
 export interface ContentBlock {
@@ -31,7 +32,7 @@ export interface NotificationSource {
   version_id: string;
 }
 
-export interface FeedItem {
+export interface FeedItem<T = GenericData> {
   __cursor: string;
   id: string;
   activities: Activity[];
@@ -41,9 +42,10 @@ export interface FeedItem {
   updated_at: string;
   read_at: string | null;
   seen_at: string | null;
+  archived_at: string | null;
   total_activities: number;
   total_actors: number;
-  data: GenericData;
+  data: T;
   source: NotificationSource;
 }
 

--- a/src/clients/Feed/store.ts
+++ b/src/clients/Feed/store.ts
@@ -69,6 +69,7 @@ export default function createStore() {
       }),
 
     setMetadata: (metadata) => set(() => ({ metadata })),
+
     setItemAttrs: (itemIds, attrs) => {
       // Create a map for the items to the updates to be made
       const itemUpdatesMap: { [id: string]: object } = itemIds.reduce(

--- a/src/clients/Feed/types.ts
+++ b/src/clients/Feed/types.ts
@@ -28,7 +28,7 @@ export type FeedMessagesReceivedPayload = {
 Event types:
 - `messages.new`: legacy event fired for all messages (feed items) received, real-time or not
 - `items.received.realtime`: all real-time items received via a socket update
-- `items.received.fetched`: invoked every time a page is fetched (like on initial load)
+- `items.received.page`: invoked every time a page is fetched (like on initial load)
 */
 export type FeedRealTimeEvent = "messages.new";
 

--- a/src/clients/Feed/types.ts
+++ b/src/clients/Feed/types.ts
@@ -28,15 +28,15 @@ export type FeedMessagesReceivedPayload = {
 Event types:
 
 - `messages.new`: legacy event fired for all messages (feed items) received, real-time or not
-- `items.new`: all real-time items received
+- `items.new`: all real-time items received via a socket update
 - `items.fetched`: invoked every time a page is fetched (like on initial load)
 */
 export type FeedEvent = "messages.new" | "items.new" | "items.fetched";
 
 export type FeedEventPayload = {
-  event: FeedEvent;
+  event: Omit<FeedEvent, "messages.new">;
   items: FeedItem[];
-  metadata?: FeedMetadata;
+  metadata: FeedMetadata;
 };
 
 export type NewMessagesFeedEventCallback = (resp: FeedResponse) => void;

--- a/src/clients/Feed/types.ts
+++ b/src/clients/Feed/types.ts
@@ -31,7 +31,8 @@ Event types:
 - `items.new`: all real-time items received via a socket update
 - `items.fetched`: invoked every time a page is fetched (like on initial load)
 */
-export type FeedEvent = "messages.new" | "items.new" | "items.fetched";
+export type FeedRealTimeEvent = "messages.new";
+export type FeedEvent = FeedRealTimeEvent | "items.new" | "items.fetched";
 
 export type FeedEventPayload = {
   event: Omit<FeedEvent, "messages.new">;
@@ -39,7 +40,7 @@ export type FeedEventPayload = {
   metadata: FeedMetadata;
 };
 
-export type NewMessagesFeedEventCallback = (resp: FeedResponse) => void;
+export type FeedRealTimeCallback = (resp: FeedResponse) => void;
 
 export type FeedEventCallback = (payload: FeedEventPayload) => void;
 

--- a/src/clients/Feed/types.ts
+++ b/src/clients/Feed/types.ts
@@ -26,13 +26,19 @@ export type FeedMessagesReceivedPayload = {
 
 /*
 Event types:
-
 - `messages.new`: legacy event fired for all messages (feed items) received, real-time or not
-- `items.new`: all real-time items received via a socket update
-- `items.fetched`: invoked every time a page is fetched (like on initial load)
+- `items.received.realtime`: all real-time items received via a socket update
+- `items.received.fetched`: invoked every time a page is fetched (like on initial load)
 */
 export type FeedRealTimeEvent = "messages.new";
-export type FeedEvent = FeedRealTimeEvent | "items.new" | "items.fetched";
+
+export type FeedEvent =
+  | FeedRealTimeEvent
+  | "items.received.page"
+  | "items.received.realtime";
+
+// Because we can bind to wild card feed events, this is here to accomodate
+export type BindableFeedEvent = FeedEvent | "items.received.*";
 
 export type FeedEventPayload = {
   event: Omit<FeedEvent, "messages.new">;

--- a/src/clients/Feed/types.ts
+++ b/src/clients/Feed/types.ts
@@ -24,8 +24,23 @@ export type FeedMessagesReceivedPayload = {
   metadata: FeedMetadata;
 };
 
-export type FeedRealTimeEvent = "messages.new";
+/*
+Event types:
 
-export type FeedRealTimeCallback = (resp: FeedResponse) => void;
+- `messages.new`: legacy event fired for all messages (feed items) received, real-time or not
+- `items.new`: all real-time items received
+- `items.fetched`: invoked every time a page is fetched (like on initial load)
+*/
+export type FeedEvent = "messages.new" | "items.new" | "items.fetched";
+
+export type FeedEventPayload = {
+  event: FeedEvent;
+  items: FeedItem[];
+  metadata?: FeedMetadata;
+};
+
+export type NewMessagesFeedEventCallback = (resp: FeedResponse) => void;
+
+export type FeedEventCallback = (payload: FeedEventPayload) => void;
 
 export type FeedItemOrItems = FeedItem | FeedItem[];

--- a/yarn.lock
+++ b/yarn.lock
@@ -1722,10 +1722,10 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-eventemitter3@^4.0.7:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
-  integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
+eventemitter2@^6.4.5:
+  version "6.4.5"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-6.4.5.tgz#97380f758ae24ac15df8353e0cc27f8b95644655"
+  integrity sha512-bXE7Dyc1i6oQElDG0jMRZJrRAn9QR2xyyFGmBdZleNmyQX0FqGYmhZIrIrpPfm/w//LTo4tVQGOGQcGCb5q9uw==
 
 fast-deep-equal@^3.1.1:
   version "3.1.3"


### PR DESCRIPTION
This PR adds two new types of events into the Knock client, for being able to more easily handle different types of fetches:

* `items.received.page`: Invoked every time a page is fetched from the feed, including an initial load
* `items.received.realtime`: Invoked when a new set of items is received via a socket

Both of these events now receive a `FeedEventPayload` 

Additionally, this PR also:

* Improves the typing on a `FeedItem` such that it can now receive a data type, so that feed items can have their data payloads typed.
* Adds a missing `archived_at` property on `FeedItem`
* Allows `data` on `FeedItem` to be nullable
* Added `eventemitter2` so we can listen to wildcard events like `items.received.*`