### PR TITLE
feat(api): expose socket via api client

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -23,8 +23,12 @@ class ApiClient {
   private apiKey: string;
   private userToken: string | null;
   private axiosClient: AxiosInstance;
-  private socket: Socket;
+
+  /**
+   * @deprecated Use `socket.connectionState` instead.
+   */
   public socketConnected = false;
+  public socket: Socket;
 
   constructor(options: ApiClientOptions) {
     this.host = options.host;
@@ -56,6 +60,9 @@ class ApiClient {
     });
   }
 
+  /**
+   * @deprecated Use `socket.connect()` instead.
+   */
   connectSocket() {
     if (this.socketConnected) {
       return;
@@ -67,11 +74,18 @@ class ApiClient {
     });
   }
 
+  /**
+   * @deprecated Use `socket.disconnect()` instead.
+   */
   disconnectSocket() {
     this.socket.disconnect();
+    this.socketConnected = false;
     return;
   }
 
+  /**
+   * @deprecated Use `socket.channel(name: string, params?: object)` instead.
+   */
   createChannel(name: string, params?: object) {
     return this.socket.channel(name, params);
   }

--- a/src/clients/feed/feed.ts
+++ b/src/clients/feed/feed.ts
@@ -55,9 +55,9 @@ class Feed {
     this.defaultOptions = options;
 
     // Try and connect to the socket
-    this.apiClient.connectSocket();
+    this.apiClient.socket.connect();
 
-    this.channel = this.apiClient.createChannel(
+    this.channel = this.apiClient.socket.channel(
       `feeds:${this.userFeedId}`,
       this.defaultOptions,
     );

--- a/src/knock.ts
+++ b/src/knock.ts
@@ -61,9 +61,11 @@ class Knock {
 
   // Used to teardown any connected instances
   teardown() {
-    if (this.apiClient) {
-      this.apiClient.disconnectSocket();
+    if (!this.apiClient) {
+      return;
     }
+
+    this.apiClient.socket.disconnect();
   }
 }
 


### PR DESCRIPTION
* Exposes `Socket` via the `ApiClient` class for easier access (so folks can do `Knock.client().socket`)
* Deprecates socket function wrappers on the api client in favor of using the socket directly
 
[Internal issue: KNO-1146](https://linear.app/knock/issue/KNO-1146/[client-js]-expose-websocket)