### PR TITLE
fix: more resilience for ssr and introduce feed teardown

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
     "@babel/plugin-transform-runtime": "^7.16.7",
     "@babel/preset-env": "^7.16.7",
     "@babel/preset-typescript": "^7.16.7",
-    "@types/phoenix": "^1.5.1",
+    "@types/phoenix": "^1.5.4",
     "@typescript-eslint/eslint-plugin": "^5.4.0",
     "@typescript-eslint/parser": "^5.4.0",
     "cross-env": "^7.0.3",

--- a/src/knock.ts
+++ b/src/knock.ts
@@ -61,10 +61,7 @@ class Knock {
 
   // Used to teardown any connected instances
   teardown() {
-    if (!this.apiClient) {
-      return;
-    }
-
+    if (!this.apiClient) return;
     this.apiClient.socket.disconnect();
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1146,10 +1146,10 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
-"@types/phoenix@^1.5.1":
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/@types/phoenix/-/phoenix-1.5.1.tgz#1cee8eda69ca5b2eff48f0fe1833d9716a17fec2"
-  integrity sha512-VPVQAOffPXztCAoLKTjSM+NqhD1gWow3XHF01gdLPeIWEQakoFjg5uGokq8BnX7KM00PWN1XnX5d4FMSxlVv3w==
+"@types/phoenix@^1.5.4":
+  version "1.5.4"
+  resolved "https://registry.yarnpkg.com/@types/phoenix/-/phoenix-1.5.4.tgz#c08a1da6d7b4e365f6a1fe1ff9aada55f5356d24"
+  integrity sha512-L5eZmzw89eXBKkiqVBcJfU1QGx9y+wurRIEgt0cuLH0hwNtVUxtx+6cu0R2STwWj468sjXyBYPYDtGclUd1kjQ==
 
 "@typescript-eslint/eslint-plugin@^5.4.0":
   version "5.9.0"


### PR DESCRIPTION
* Falls back to long polling when websockets aren't available
* Better handles socket connections on the feed `listenForUpdates` method
* Adds a new `teardown` method to the feed
* Removes deprecated functions in the API client
