### PR TITLE
feat(feeds): support new archived filter

### DIFF
--- a/src/clients/feed/feed.ts
+++ b/src/clients/feed/feed.ts
@@ -32,7 +32,7 @@ export type Status =
   | "unarchived";
 
 // Default options to apply
-const feedClientDefaults: FeedClientOptions = {
+const feedClientDefaults: Pick<FeedClientOptions, "archived"> = {
   archived: "exclude",
 };
 

--- a/src/clients/feed/feed.ts
+++ b/src/clients/feed/feed.ts
@@ -209,7 +209,7 @@ class Feed {
       const unreadCount = normalizedItems.filter((i) => !i.read_at).length;
 
       // Build the new metadata
-      const updatedMetdata = {
+      const updatedMetadata = {
         ...state.metadata,
         total_count: state.metadata.total_count - normalizedItems.length,
         unseen_count: state.metadata.unseen_count - unseenCount,
@@ -224,7 +224,7 @@ class Feed {
       setState((state) =>
         state.setResult({
           entries: entriesToSet,
-          meta: updatedMetdata,
+          meta: updatedMetadata,
           page_info: state.pageInfo,
         }),
       );

--- a/src/clients/feed/interfaces.ts
+++ b/src/clients/feed/interfaces.ts
@@ -12,7 +12,9 @@ export interface FeedClientOptions {
   source?: string;
   // Optionally scope all requests to a particular tenant
   tenant?: string;
-  include_archived?: boolean;
+
+  // Optionally scope to a given archived status (defaults to `exclude`)
+  archived?: "include" | "exclude" | "only";
 }
 
 export type FetchFeedOptions = {


### PR DESCRIPTION
We added support on the backend for a new `archived` filter that can be one of three states: `include`, `exclude`, `only`. This PR introduces support for this new filter in the feed client, and deprecates the only `include_archived` default as well.

To support the new archived states this PR also:

- Adds correct defaults so that `defaultOptions` always sets `archived` to `exclude`
- Fixes optimistic updating when the feed is scoped to an archive filter other than `exclude`

[Internal ticket](https://linear.app/knock/issue/KNO-1660/[feeds]-support-more-archived-query-options)