### PR TITLE
Indicate that WorkflowPreferenceSetting can be undefined

### DIFF
--- a/src/clients/preferences/interfaces.ts
+++ b/src/clients/preferences/interfaces.ts
@@ -10,7 +10,7 @@ export type WorkflowPreferenceSetting =
   | boolean
   | { channel_types: ChannelTypePreferences };
 
-export type WorkflowPreferences = Record<string, WorkflowPreferenceSetting | undefined>;
+export type WorkflowPreferences = Partial<Record<string, WorkflowPreferenceSetting>;
 
 export interface SetPreferencesProperties {
   workflows: WorkflowPreferences;

--- a/src/clients/preferences/interfaces.ts
+++ b/src/clients/preferences/interfaces.ts
@@ -10,7 +10,7 @@ export type WorkflowPreferenceSetting =
   | boolean
   | { channel_types: ChannelTypePreferences };
 
-export type WorkflowPreferences = Partial<Record<string, WorkflowPreferenceSetting>;
+export type WorkflowPreferences = Partial<Record<string, WorkflowPreferenceSetting>>;
 
 export interface SetPreferencesProperties {
   workflows: WorkflowPreferences;

--- a/src/clients/preferences/interfaces.ts
+++ b/src/clients/preferences/interfaces.ts
@@ -10,9 +10,7 @@ export type WorkflowPreferenceSetting =
   | boolean
   | { channel_types: ChannelTypePreferences };
 
-export interface WorkflowPreferences {
-  [key: string]: WorkflowPreferenceSetting;
-}
+export type WorkflowPreferences = Record<string, WorkflowPreferenceSetting | undefined>;
 
 export interface SetPreferencesProperties {
   workflows: WorkflowPreferences;


### PR DESCRIPTION
# Undefined workflow preference settings

Introduce possibility of `undefined` to the type

Using `[key: string]: WorkflowPreferenceSetting` Typescript will think we always have a value
