### PR TITLE
feat: add better type definitions for feed items

### DIFF
--- a/src/clients/feed/interfaces.ts
+++ b/src/clients/feed/interfaces.ts
@@ -1,4 +1,4 @@
-import { Activity, GenericData, User, PageInfo } from "../../interfaces";
+import { Activity, GenericData, PageInfo, Recipient } from "../../interfaces";
 import { NetworkStatus } from "../../networkStatus";
 
 // Specific feed interfaces
@@ -12,7 +12,6 @@ export interface FeedClientOptions {
   source?: string;
   // Optionally scope all requests to a particular tenant
   tenant?: string;
-
   // Optionally scope to a given archived status (defaults to `exclude`)
   archived?: "include" | "exclude" | "only";
 }
@@ -37,8 +36,8 @@ export interface NotificationSource {
 export interface FeedItem<T = GenericData> {
   __cursor: string;
   id: string;
-  activities: Activity[];
-  actors: User[];
+  activities: Activity<T>[];
+  actors: Recipient[];
   blocks: ContentBlock[];
   inserted_at: string;
   updated_at: string;
@@ -49,6 +48,7 @@ export interface FeedItem<T = GenericData> {
   total_actors: number;
   data: T | null;
   source: NotificationSource;
+  tenant: string | null;
 }
 
 export interface FeedMetadata {

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -17,8 +17,10 @@ export interface KnockObject<T = GenericData> {
 
 export interface User extends GenericData {
   id: string;
-  email: string;
-  name: string;
+  email: string | null;
+  name: string | null;
+  phone_number: string | null;
+  avatar: string | null;
   updated_at: string;
   created_at: string | null;
 }
@@ -29,11 +31,13 @@ export interface PageInfo {
   page_size: number;
 }
 
-export interface Activity {
+export type Recipient = User | KnockObject;
+
+export interface Activity<T = GenericData> {
   id: string;
   inserted_at: string;
   updated_at: string;
-  recipient: User;
-  actor: User;
-  data: GenericData;
+  recipient: Recipient;
+  actor: Recipient | null;
+  data: T | null;
 }


### PR DESCRIPTION
* Adds `tenant` as a nullable string on `FeedItem` (was missing)
* Ensures that `actor` can be nullable on `Activity`
* Adds new `Recipient` type that represents a User or a KnockObject
* Makes `name` and `email` nullable strings on User
* Adds missing `phone_number` / `avatar` types on User