### PR TITLE
feat(kno-2198): add support for has_tenant query param for the feeds API

### DIFF
--- a/src/clients/feed/interfaces.ts
+++ b/src/clients/feed/interfaces.ts
@@ -12,6 +12,8 @@ export interface FeedClientOptions {
   source?: string;
   // Optionally scope all requests to a particular tenant
   tenant?: string;
+  // Optionally scope to notifications with any tenancy or no tenancy
+  has_tenant?: boolean;
   // Optionally scope to a given archived status (defaults to `exclude`)
   archived?: "include" | "exclude" | "only";
 }


### PR DESCRIPTION
- `has_tenant: true` returns notifications that are scoped to any tenant
- `has_tenant: false` returns notifications that are not scoped to any tenant