### PR TITLE
feat: broadcast message events and introduce a broadcastchannel

### DIFF
--- a/src/clients/feed/interfaces.ts
+++ b/src/clients/feed/interfaces.ts
@@ -16,12 +16,14 @@ export interface FeedClientOptions {
   has_tenant?: boolean;
   // Optionally scope to a given archived status (defaults to `exclude`)
   archived?: "include" | "exclude" | "only";
+  // Optionally enable cross browser feed updates for this feed
+  __experimentalCrossBrowserUpdates?: boolean;
 }
 
 export type FetchFeedOptions = {
   __loadingType?: NetworkStatus.loading | NetworkStatus.fetchMore;
   __fetchSource?: "socket" | "http";
-} & FeedClientOptions;
+} & Omit<FeedClientOptions, "__experimentalCrossBrowserUpdates">;
 
 export interface ContentBlock {
   content: string;

--- a/src/clients/feed/types.ts
+++ b/src/clients/feed/types.ts
@@ -35,10 +35,16 @@ export type FeedRealTimeEvent = "messages.new";
 export type FeedEvent =
   | FeedRealTimeEvent
   | "items.received.page"
-  | "items.received.realtime";
+  | "items.received.realtime"
+  | "items.archived"
+  | "items.unarchived"
+  | "items.seen"
+  | "items.unseen"
+  | "items.read"
+  | "items.unread";
 
-// Because we can bind to wild card feed events, this is here to accomodate
-export type BindableFeedEvent = FeedEvent | "items.received.*";
+// Because we can bind to wild card feed events, this is here to accomodate whatever can be bound to
+export type BindableFeedEvent = FeedEvent | "items.received.*" | "items.*";
 
 export type FeedEventPayload = {
   event: Omit<FeedEvent, "messages.new">;


### PR DESCRIPTION
## Changes in this PR

* introduces new `items:{{ status }}` events for when messages are seen, read, archived
* adds a new broadcastchannel to the feed so that events can be broadcast across browser contexts
* adds a new `__experimentalCrossBrowserUpdates` option, which when enabled, will allow item updates to refetch the feed state

## What does this solve?

- Exposing item events allows our customers to bind listeners for handling things like "when an item is archived on feed 1, then update feed 2"
- Exposing a broadcast channel enables feed state to be more easily sync'd across different browser windows (e.g. feed count being the same for the same feed across multiple windows)

## Can't everything just be in a broadcast channel?

- We have an event emitter AND a broadcast channel because we don't want to just assume that all customers want to publish and consume all events
- We also can't use a broadcast channel to solve the multi feed usecase (e.g. regular feed and archive feed) because they are running in the same browser window / context and broadcast channels only ever publish messages to **other** contexts

## Demo
https://www.loom.com/share/2f6bcdd4f4e14f99b92e51a404be2563
