### PR TITLE
feat: add new markAllAsArchived, Seen, Unread methods on feed

### DIFF
--- a/src/clients/feed/feed.ts
+++ b/src/clients/feed/feed.ts
@@ -66,8 +66,8 @@ class Feed {
 
     this.channel.on("new-message", (resp) => this.onNewMessageReceived(resp));
 
-    // Attempt to bind to listen to other events from this feed in different tabs for when
-    // `items:updated` event is
+    // Attempt to bind to listen to other events from this feed in different tabs
+    // Note: here we ensure `self` is available (it's not in server rendered envs)
     this.broadcastChannel =
       self && "BroadcastChannel" in self
         ? new BroadcastChannel(`knock:feed:${this.userFeedId}`)
@@ -608,10 +608,13 @@ class Feed {
   }
 
   private broadcastOverChannel(type: string, payload: any) {
+    // The broadcastChannel may not be available in non-browser environments
     if (!this.broadcastChannel) {
       return;
     }
 
+    // Here we stringify our payload and try and send as JSON such that we
+    // don't get any `An object could not be cloned` errors when trying to broadcast
     try {
       const stringifiedPayload = JSON.parse(JSON.stringify(payload));
 

--- a/src/clients/feed/store.ts
+++ b/src/clients/feed/store.ts
@@ -16,29 +16,27 @@ const defaultSetResultOptions = {
   shouldAppend: false,
 };
 
+const initialStoreState = {
+  items: [],
+  metadata: {
+    total_count: 0,
+    unread_count: 0,
+    unseen_count: 0,
+  },
+  pageInfo: {
+    before: null,
+    after: null,
+    page_size: 50,
+  },
+};
+
 export default function createStore() {
   return create<FeedStoreState>((set) => ({
     // Keeps track of all of the items loaded
-    items: [],
-
+    ...initialStoreState,
     // The network status indicates what's happening with the request
     networkStatus: NetworkStatus.ready,
     loading: false,
-
-    // Keeps track of the current badge counts
-    metadata: {
-      total_count: 0,
-      unread_count: 0,
-      unseen_count: 0,
-    },
-
-    // Keeps track of the last full page of results we received (for paginating)
-    pageInfo: {
-      before: null,
-      after: null,
-      page_size: 50,
-    },
-
     // TODO: remove this function from the store as we're now using the
     // `setNetworkStatus` function to derive this information instead
     setLoading: (loading) => set(() => ({ loading })),
@@ -69,6 +67,9 @@ export default function createStore() {
       }),
 
     setMetadata: (metadata) => set(() => ({ metadata })),
+
+    resetStore: (metadata = initialStoreState.metadata) =>
+      set(() => ({ ...initialStoreState, metadata })),
 
     setItemAttrs: (itemIds, attrs) => {
       // Create a map for the items to the updates to be made

--- a/src/clients/feed/types.ts
+++ b/src/clients/feed/types.ts
@@ -18,6 +18,7 @@ export type FeedStoreState = {
   setLoading: (loading: boolean) => void;
   setNetworkStatus: (networkStatus: NetworkStatus) => void;
   setItemAttrs: (itemIds: string[], attrs: object) => void;
+  resetStore: (metadata?: FeedMetadata) => void;
 };
 
 export type FeedMessagesReceivedPayload = {
@@ -41,7 +42,10 @@ export type FeedEvent =
   | "items.seen"
   | "items.unseen"
   | "items.read"
-  | "items.unread";
+  | "items.unread"
+  | "items.all_archived"
+  | "items.all_read"
+  | "items.all_seen";
 
 // Because we can bind to wild card feed events, this is here to accomodate whatever can be bound to
 export type BindableFeedEvent = FeedEvent | "items.received.*" | "items.*";


### PR DESCRIPTION
This PR adds the following new functions to the `Feed`:

* `markAllAsArchived`
* `markAllAsSeen`
* `markAllAsRead`

Internally these rely on the bulk message change endpoint for a given channel's messages, meaning that ALL messages for this user on the feed channel are marked as the status indicated. This uses an async bulk operation under the hood.

Here on the client, we try and do some optimistic updates on the store so that these changes propagate instantly and don't need to rely on the behavior of polling the async job to understand when they are "done".

Additionally, there are a set of new events that go alongside this update: `items.all_archived`, `items.all_read`, `items.all_seen` which are also emitted once the API request has been made.

You'll see the following note in the code right now about a potential race-condition that exists in this implementation:

> // Note: there is the potential for a race condition here because the bulk
>  // update is an async method, so if a new message comes in during this window before
> // the update has been processed we'll effectively reset the `unseen_count` to be what it was.

Unfortunately with the deferred approach, we're taking here I'm not 100% sure what we can do to fix this right now. I had thought that we could flag the store as not available to be written to or something and then poll to see when the job is completed, but that feels like an over-optimization for the time being and as such, I'm opting to ship this as is.