### PR TITLE
feat(kno-2612): support filtering feed by trigger data

### DIFF
--- a/src/clients/feed/interfaces.ts
+++ b/src/clients/feed/interfaces.ts
@@ -16,6 +16,8 @@ export interface FeedClientOptions {
   has_tenant?: boolean;
   // Optionally scope to a given archived status (defaults to `exclude`)
   archived?: "include" | "exclude" | "only";
+  // Optionally scope all notifications that contain this argument as part of their trigger payload
+  trigger_data?: GenericData;
   // Optionally enable cross browser feed updates for this feed
   __experimentalCrossBrowserUpdates?: boolean;
 }

--- a/src/clients/preferences/interfaces.ts
+++ b/src/clients/preferences/interfaces.ts
@@ -10,7 +10,9 @@ export type WorkflowPreferenceSetting =
   | boolean
   | { channel_types: ChannelTypePreferences };
 
-export type WorkflowPreferences = Partial<Record<string, WorkflowPreferenceSetting>>;
+export type WorkflowPreferences = Partial<
+  Record<string, WorkflowPreferenceSetting>
+>;
 
 export interface SetPreferencesProperties {
   workflows: WorkflowPreferences;


### PR DESCRIPTION
Allow configuring `trigger_data` parameter on user feed request.