### PR TITLE
feat(kno-2896): add markAsInteracted to feed

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -7,5 +7,8 @@
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/recommended"
-  ]
-} 
+  ],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": "off"
+  }
+}

--- a/src/clients/feed/feed.ts
+++ b/src/clients/feed/feed.ts
@@ -26,6 +26,7 @@ import { isRequestInFlight, NetworkStatus } from "../../networkStatus";
 export type Status =
   | "seen"
   | "read"
+  | "interacted"
   | "archived"
   | "unseen"
   | "unread"
@@ -290,6 +291,21 @@ class Feed {
     );
 
     return this.makeStatusUpdate(itemOrItems, "unread");
+  }
+
+  async markAsInteracted(itemOrItems: FeedItemOrItems) {
+    const now = new Date().toISOString();
+    this.optimisticallyPerformStatusUpdate(
+      itemOrItems,
+      "interacted",
+      {
+        read_at: now,
+        interacted_at: now,
+      },
+      "unread_count",
+    );
+
+    return this.makeStatusUpdate(itemOrItems, "interacted");
   }
 
   /*


### PR DESCRIPTION
Adds `markAsInteracted` method to the `Feed` class, for use in the in-app feed library.