### PR TITLE
fix: ensure rendering without a window can occur

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -24,7 +24,7 @@ class ApiClient {
   private userToken: string | null;
   private axiosClient: AxiosInstance;
 
-  public socket: Socket;
+  public socket: Socket | undefined;
 
   constructor(options: ApiClientOptions) {
     this.host = options.host;
@@ -42,14 +42,15 @@ class ApiClient {
       },
     });
 
-    this.socket = new Socket(`${this.host.replace("http", "ws")}/ws/v1`, {
-      // If we're in a non-browser environment, then fallback to longpolling
-      transport: typeof window === "undefined" ? LongPoll : window.WebSocket,
-      params: {
-        user_token: this.userToken,
-        api_key: this.apiKey,
-      },
-    });
+    if (typeof window !== "undefined") {
+      this.socket = new Socket(`${this.host.replace("http", "ws")}/ws/v1`, {
+        transport: window.WebSocket,
+        params: {
+          user_token: this.userToken,
+          api_key: this.apiKey,
+        },
+      });
+    }
 
     axiosRetry(this.axiosClient, {
       retries: 3,

--- a/src/knock.ts
+++ b/src/knock.ts
@@ -70,7 +70,9 @@ class Knock {
   // Used to teardown any connected instances
   teardown() {
     if (!this.apiClient) return;
-    this.apiClient.socket.disconnect();
+    if (this.apiClient.socket) {
+      this.apiClient.socket.disconnect();
+    }
   }
 }
 


### PR DESCRIPTION
Fixes issues in non-client environments, like when the client is used in a next js SSR app.

* Ensures that `self` is defined 
* Ensures that the socket is only initiated in an environment with `window`
* Allows `Socket` and `Channel` to be undefined