### PR TITLE
feat(KNO-4330): Add webhook channel type

### DIFF
--- a/src/clients/preferences/interfaces.ts
+++ b/src/clients/preferences/interfaces.ts
@@ -1,6 +1,6 @@
 // Channel types supported in Knock
 // TODO: it would be great to pull this in from an external location
-export type ChannelType = "email" | "in_app_feed" | "sms" | "push" | "chat";
+export type ChannelType = "email" | "in_app_feed" | "sms" | "push" | "chat" | "http";
 
 export type ChannelTypePreferences = {
   [K in ChannelType]?: boolean;


### PR DESCRIPTION
This PR updates our channel types to support webhook types (http).

Slack conversation with the client that requested this change: https://knockcustomers.slack.com/archives/C033CKE13SS/p1695066936862249?thread_ts=1694900805.437269&cid=C033CKE13SS