### PR TITLE
fix: specify types location in the default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "exports": {
     ".": {
       "require": "./dist/cjs/index.js",
+      "types": "./dist/types/index.d.ts",
       "default": "./dist/esm/index.js"
     }
   },


### PR DESCRIPTION
Types won't fallback to the root `types` property for es modules loading knock's sdk, so none of knocks types were being exported.