### PR TITLE
feat: add preference overlay support and standardize methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,10 +43,6 @@ knockClient.authenticate(
 );
 ```
 
-## Usage
-
-You can find an example usage in a React application in the [example/App.js](https://github.com/knocklabs/client-js/blob/main/example/src/App.js) file, which is a plain-old Create React App.
-
 ### Retrieving new items from the feed
 
 ```typescript
@@ -159,7 +155,7 @@ feedClient.markAsUnarchived(feedItemOrItems);
 
 ```typescript
 // Set an entire preference set
-await knockClient.preferences.set({
+await knockClient.user.setPreferences({
   channel_types: { email: true, sms: false },
   workflows: {
     "dinosaurs-loose": {
@@ -169,33 +165,25 @@ await knockClient.preferences.set({
 });
 
 // Retrieve a whole preference set
-const preferences = await knockClient.preferences.get();
+const preferences = await knockClient.user.getPreferences();
 
-// Granular preference setting for channel types
-await knockClient.preferences.setChannelType("email", false);
-
-// Granular preference setting for workflows
-await knockClient.preferences.setWorkflow("dinosaurs-loose", {
-  channel_types: {
-    email: true,
-    in_app_feed: false,
-  },
-});
+// Retrieve all preference sets for the user
+const preferenceSets = await knockClient.user.getAllPreferences();
 ```
 
 ### Managing the current user's channel data
 
 ```typescript
 // Get user channel data
-await knockClient.user.getChannelData({
-  channelId: "channel-id",
+const channelData = await knockClient.user.getChannelData({
+  channelId: "uuid-knock-channel-id",
 });
 ```
 
 ```typescript
 // Set push channel data for a user
 await knockClient.user.setChannelData({
-  channelId: "channel-id",
+  channelId: "uuid-knock-channel-id",
   channelData: {
     tokens: ["apns-user-push-token"],
   },

--- a/src/clients/preferences/index.ts
+++ b/src/clients/preferences/index.ts
@@ -27,6 +27,9 @@ class Preferences {
     this.instance = instance;
   }
 
+  /**
+   * @deprecated Use `user.getAllPreferences()` instead
+   */
   async getAll() {
     const result = await this.instance.client().makeRequest({
       method: "GET",
@@ -36,6 +39,9 @@ class Preferences {
     return this.handleResponse(result);
   }
 
+  /**
+   * @deprecated Use `user.getPreferences()` instead
+   */
   async get(options: PreferenceOptions = {}) {
     const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
 
@@ -47,6 +53,9 @@ class Preferences {
     return this.handleResponse(result);
   }
 
+  /**
+   * @deprecated Use `user.setPreferences(preferenceSet, options)` instead
+   */
   async set(
     preferenceSet: SetPreferencesProperties,
     options: PreferenceOptions = {},
@@ -62,6 +71,9 @@ class Preferences {
     return this.handleResponse(result);
   }
 
+  /**
+   * @deprecated Use `user.setPreferences(preferenceSet, options)` instead
+   */
   async setChannelTypes(
     channelTypePreferences: ChannelTypePreferences,
     options: PreferenceOptions = {},
@@ -77,6 +89,9 @@ class Preferences {
     return this.handleResponse(result);
   }
 
+  /**
+   * @deprecated Use `user.setPreferences(preferenceSet, options)` instead
+   */
   async setChannelType(
     channelType: ChannelType,
     setting: boolean,
@@ -93,6 +108,9 @@ class Preferences {
     return this.handleResponse(result);
   }
 
+  /**
+   * @deprecated Use `user.setPreferences(preferenceSet, options)` instead
+   */
   async setWorkflows(
     workflowPreferences: WorkflowPreferences,
     options: PreferenceOptions = {},
@@ -108,6 +126,9 @@ class Preferences {
     return this.handleResponse(result);
   }
 
+  /**
+   * @deprecated Use `user.setPreferences(preferenceSet, options)` instead
+   */
   async setWorkflow(
     workflowKey: string,
     setting: WorkflowPreferenceSetting,
@@ -125,6 +146,9 @@ class Preferences {
     return this.handleResponse(result);
   }
 
+  /**
+   * @deprecated Use `user.setPreferences(preferenceSet, options)` instead
+   */
   async setCategories(
     categoryPreferences: WorkflowPreferences,
     options: PreferenceOptions = {},
@@ -140,6 +164,9 @@ class Preferences {
     return this.handleResponse(result);
   }
 
+  /**
+   * @deprecated Use `user.setPreferences(preferenceSet, options)` instead
+   */
   async setCategory(
     categoryKey: string,
     setting: WorkflowPreferenceSetting,

--- a/src/clients/preferences/interfaces.ts
+++ b/src/clients/preferences/interfaces.ts
@@ -1,6 +1,12 @@
 // Channel types supported in Knock
 // TODO: it would be great to pull this in from an external location
-export type ChannelType = "email" | "in_app_feed" | "sms" | "push" | "chat" | "http";
+export type ChannelType =
+  | "email"
+  | "in_app_feed"
+  | "sms"
+  | "push"
+  | "chat"
+  | "http";
 
 export type ChannelTypePreferences = {
   [K in ChannelType]?: boolean;
@@ -29,4 +35,8 @@ export interface PreferenceSet {
 
 export interface PreferenceOptions {
   preferenceSet?: string;
+}
+
+export interface GetPreferencesOptions extends PreferenceOptions {
+  tenant?: string;
 }

--- a/src/clients/users/index.ts
+++ b/src/clients/users/index.ts
@@ -1,14 +1,15 @@
 import { ApiResponse } from "../../api";
+import { ChannelData } from "../../interfaces";
 import Knock from "../../knock";
+import {
+  GetPreferencesOptions,
+  PreferenceOptions,
+  PreferenceSet,
+  SetPreferencesProperties,
+} from "../preferences/interfaces";
+import { GetChannelDataInput, SetChannelDataInput } from "./interfaces";
 
-type SetChannelDataInput = {
-  channelId: string;
-  channelData: Record<string, any>;
-};
-
-type GetChannelDataInput = {
-  channelId: string;
-};
+const DEFAULT_PREFERENCE_SET_ID = "default";
 
 class UserClient {
   private instance: Knock;
@@ -17,31 +18,72 @@ class UserClient {
     this.instance = instance;
   }
 
-  async getChannelData(params: GetChannelDataInput) {
+  async getAllPreferences() {
+    const result = await this.instance.client().makeRequest({
+      method: "GET",
+      url: `/v1/users/${this.instance.userId}/preferences`,
+    });
+
+    return this.handleResponse<PreferenceSet[]>(result);
+  }
+
+  async getPreferences(
+    options: GetPreferencesOptions = {},
+  ): Promise<PreferenceSet> {
+    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
+
+    const result = await this.instance.client().makeRequest({
+      method: "GET",
+      url: `/v1/users/${this.instance.userId}/preferences/${preferenceSetId}`,
+      params: { tenant: options.tenant },
+    });
+
+    return this.handleResponse<PreferenceSet>(result);
+  }
+
+  async setPreferences(
+    preferenceSet: SetPreferencesProperties,
+    options: PreferenceOptions = {},
+  ): Promise<PreferenceSet> {
+    const preferenceSetId = options.preferenceSet || DEFAULT_PREFERENCE_SET_ID;
+
+    const result = await this.instance.client().makeRequest({
+      method: "PUT",
+      url: `/v1/users/${this.instance.userId}/preferences/${preferenceSetId}`,
+      data: preferenceSet,
+    });
+
+    return this.handleResponse<PreferenceSet>(result);
+  }
+
+  async getChannelData<T = any>(params: GetChannelDataInput) {
     const result = await this.instance.client().makeRequest({
       method: "GET",
       url: `/v1/users/${this.instance.userId}/channel_data/${params.channelId}`,
     });
 
-    return this.handleResponse(result);
+    return this.handleResponse<ChannelData<T>>(result);
   }
 
-  async setChannelData({ channelId, channelData }: SetChannelDataInput) {
+  async setChannelData<T = any>({
+    channelId,
+    channelData,
+  }: SetChannelDataInput) {
     const result = await this.instance.client().makeRequest({
       method: "PUT",
       url: `/v1/users/${this.instance.userId}/channel_data/${channelId}`,
       data: { data: channelData },
     });
 
-    return this.handleResponse(result);
+    return this.handleResponse<ChannelData<T>>(result);
   }
 
-  private handleResponse(response: ApiResponse) {
+  private handleResponse<T>(response: ApiResponse) {
     if (response.statusCode === "error") {
       throw new Error(response.error || response.body);
     }
 
-    return response.body;
+    return response.body as T;
   }
 }
 

--- a/src/clients/users/interfaces.ts
+++ b/src/clients/users/interfaces.ts
@@ -1,0 +1,8 @@
+export interface SetChannelDataInput {
+  channelId: string;
+  channelData: Record<string, any>;
+}
+
+export interface GetChannelDataInput {
+  channelId: string;
+}

--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -41,3 +41,8 @@ export interface Activity<T = GenericData> {
   actor: Recipient | null;
   data: T | null;
 }
+
+export interface ChannelData<T = any> {
+  channel_id: string;
+  data: T;
+}


### PR DESCRIPTION
- Adds support for passing `tenant` to get preferences
- Moves preference methods under `user` namespace
- Deprecates old preference methods
- Adds support for typing channel data